### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> ⚠️ **This repository is archived.**
+>
+> Tigris has pivoted from this database project to a new, globally distributed S3-compatible object storage service.
+> Learn more about the new product here: https://www.tigrisdata.com/
+
 <a name="readme-top"></a>
 
 [![Next][Next.js]][Next-url]


### PR DESCRIPTION
This PR adds an archive notice to the README to reflect Tigris' pivot to a globally distributed S3-compatible object storage service.